### PR TITLE
Fix env checks in wrapper

### DIFF
--- a/wrapper
+++ b/wrapper
@@ -5,14 +5,14 @@
 
 declare -a RESPONSE=()
 
-[ -v COUNTRY ] || RESPONSE+=("environment: Specifies the COUNTRY.")
-[ -v STATE ] || RESPONSE+=("environment: Specifies the STATE.")
-[ -v CITY ] || RESPONSE+=("environment: Specifies the CITY.")
-[ -v ORGANIZATION ] || RESPONSE+=("environment: Specifies the ORGANIZATION.")
-[ -v ORGANIZATIONAL_UNIT ] || RESPONSE+=("environment: Specifies the ORGANIZATIONAL_UNIT.")
-[ -v COMMON_NAME ] || RESPONSE+=("environment: Specifies the COMMON_NAME.")
-[ -v HOST ] || RESPONSE+=("environment: Specifies the HOST.")
-[ -v PORT ] || RESPONSE+=("environment: Specifies the PORT.")
+[[ -v COUNTRY ]] || RESPONSE+=("environment: Specifies the COUNTRY.")
+[[ -v STATE ]] || RESPONSE+=("environment: Specifies the STATE.")
+[[ -v CITY ]] || RESPONSE+=("environment: Specifies the CITY.")
+[[ -v ORGANIZATION ]] || RESPONSE+=("environment: Specifies the ORGANIZATION.")
+[[ -v ORGANIZATIONAL_UNIT ]] || RESPONSE+=("environment: Specifies the ORGANIZATIONAL_UNIT.")
+[[ -v COMMON_NAME ]] || RESPONSE+=("environment: Specifies the COMMON_NAME.")
+[[ -v HOST ]] || RESPONSE+=("environment: Specifies the HOST.")
+[[ -v PORT ]] || RESPONSE+=("environment: Specifies the PORT.")
 
 # Checking if RESPONSE array is not empty, printing the messages.
 # Calling the runner function to stop the container.


### PR DESCRIPTION
## Summary
- use `[[ -v VAR ]]` to detect variables in `wrapper`

## Testing
- `bash -n wrapper`


------
https://chatgpt.com/codex/tasks/task_e_6841cff17b90832887f5aaf70691a7f5