### PR TITLE
Fix README default address

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Start the server with the default settings using:
 ./ubyte-webssh-bridge
 ```
 
-This will listen on `127.0.0.1:8080` by default.
+This will listen on `:8080` by default.
 
 ### Configuration Options
 


### PR DESCRIPTION
## Summary
- mention correct default listening address

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_6841d241387c8328982e6fe077da64c1