### PR TITLE
Add basic test suite

### DIFF
--- a/ws/config/config_test.go
+++ b/ws/config/config_test.go
@@ -1,0 +1,33 @@
+package config
+
+import "testing"
+
+func TestValidateSuccess(t *testing.T) {
+	cfg := DefaultConfiguration()
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestValidateErrors(t *testing.T) {
+	tests := []struct {
+		name   string
+		modify func(*Configuration)
+	}{
+		{"empty address", func(c *Configuration) { c.ListenAddress = "" }},
+		{"max connections", func(c *Configuration) { c.MaxConnections = 0 }},
+		{"max per host", func(c *Configuration) { c.MaxConnectionsPerHost = 0 }},
+		{"connect timeout", func(c *Configuration) { c.SSHConnectTimeout = 0 }},
+		{"auth timeout", func(c *Configuration) { c.SSHAuthTimeout = 0 }},
+		{"handshake timeout", func(c *Configuration) { c.SSHHandshakeTimeout = 0 }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := DefaultConfiguration()
+			tt.modify(cfg)
+			if err := cfg.Validate(); err == nil {
+				t.Fatalf("expected error for %s", tt.name)
+			}
+		})
+	}
+}

--- a/ws/connection/manager_test.go
+++ b/ws/connection/manager_test.go
@@ -1,0 +1,41 @@
+package connection
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+func TestParseTargetAddress(t *testing.T) {
+	m := &ConnectionManager{}
+	req := &http.Request{URL: &url.URL{Path: "/ws/host/22"}}
+	addr, err := m.ParseTargetAddress(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if addr != "host:22" {
+		t.Fatalf("expected host:22 got %s", addr)
+	}
+	req.URL.Path = "/ws/onlyhost"
+	if _, err := m.ParseTargetAddress(req); err == nil {
+		t.Fatal("expected error for invalid path")
+	}
+}
+
+func TestGetClientIP(t *testing.T) {
+	m := &ConnectionManager{}
+	req := &http.Request{Header: http.Header{}, RemoteAddr: "3.3.3.3:123"}
+	req.Header.Set("X-Forwarded-For", "1.1.1.1, 2.2.2.2")
+	if ip := m.GetClientIP(req); ip != "1.1.1.1" {
+		t.Fatalf("unexpected ip %s", ip)
+	}
+	req = &http.Request{Header: http.Header{}, RemoteAddr: "3.3.3.3:123"}
+	req.Header.Set("X-Real-IP", "2.2.2.2")
+	if ip := m.GetClientIP(req); ip != "2.2.2.2" {
+		t.Fatalf("unexpected ip %s", ip)
+	}
+	req = &http.Request{RemoteAddr: "3.3.3.3:123"}
+	if ip := m.GetClientIP(req); ip != "3.3.3.3" {
+		t.Fatalf("unexpected ip %s", ip)
+	}
+}

--- a/ws/message/processor_test.go
+++ b/ws/message/processor_test.go
@@ -1,0 +1,37 @@
+package message
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestProcessBinaryMessage(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewMessageProcessor(nil)
+	if err := p.ProcessBinaryMessage(strings.NewReader("abc"), &buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if buf.String() != "abc" {
+		t.Fatalf("expected 'abc', got %q", buf.String())
+	}
+}
+
+func TestProcessTextMessageRaw(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewMessageProcessor(nil)
+	if err := p.ProcessTextMessage(strings.NewReader("hello"), &buf, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if buf.String() != "hello" {
+		t.Fatalf("expected write to stdin, got %q", buf.String())
+	}
+}
+
+func TestProcessTextMessageUnknownAction(t *testing.T) {
+	p := NewMessageProcessor(nil)
+	err := p.ProcessTextMessage(strings.NewReader(`{"action":"unknown"}`), nil, nil)
+	if err == nil {
+		t.Fatal("expected error for unknown action")
+	}
+}

--- a/ws/ssh/config_test.go
+++ b/ws/ssh/config_test.go
@@ -1,0 +1,31 @@
+package ssh
+
+import "testing"
+
+func TestSSHTimeoutsValidate(t *testing.T) {
+	touts := DefaultSSHTimeouts()
+	if err := touts.Validate(); err != nil {
+		t.Fatalf("expected valid defaults, got %v", err)
+	}
+}
+
+func TestSSHTimeoutsValidateErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		mod  func(*SSHTimeouts)
+	}{
+		{"connect", func(s *SSHTimeouts) { s.ConnectTimeout = 0 }},
+		{"auth", func(s *SSHTimeouts) { s.AuthTimeout = 0 }},
+		{"handshake", func(s *SSHTimeouts) { s.HandshakeTimeout = 0 }},
+		{"handshake<auth", func(s *SSHTimeouts) { s.HandshakeTimeout = s.AuthTimeout - 1 }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := DefaultSSHTimeouts()
+			tt.mod(&s)
+			if err := s.Validate(); err == nil {
+				t.Fatalf("expected error for %s", tt.name)
+			}
+		})
+	}
+}

--- a/ws/utils/limiter_test.go
+++ b/ws/utils/limiter_test.go
@@ -1,0 +1,30 @@
+package utils
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRateLimiterBasic(t *testing.T) {
+	rl := NewRateLimiter(100*time.Millisecond, 2, true, nil)
+	id := "1.2.3.4"
+	if !rl.IsAllowed(id) || !rl.IsAllowed(id) {
+		t.Fatal("first two attempts should be allowed")
+	}
+	if rl.IsAllowed(id) {
+		t.Fatal("third attempt should be blocked")
+	}
+	time.Sleep(120 * time.Millisecond)
+	if !rl.IsAllowed(id) {
+		t.Fatal("should be allowed after interval")
+	}
+	rl.Close()
+}
+
+func TestRateLimiterWhitelist(t *testing.T) {
+	rl := NewRateLimiter(100*time.Millisecond, 1, true, []string{"whitelisted"})
+	if !rl.IsAllowed("whitelisted") {
+		t.Fatal("whitelisted identifier should always be allowed")
+	}
+	rl.Close()
+}


### PR DESCRIPTION
## Summary
- add configuration validation tests
- add ssh timeout validation tests
- add rate limiter tests
- add message processor tests
- add connection utility tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6862da28fdc483288edc1d28c4eb6809